### PR TITLE
Add optional project field when searching for and completing tasks

### DIFF
--- a/app.json
+++ b/app.json
@@ -220,8 +220,8 @@
           "nl": "Taak met filter bestaat..."
         },
         "titleFormatted": {
-          "en": "Task with [[filter]] !{{exists|does not exist}} ",
-          "nl": "Taak with [[filter]] !{{bestaat|bestaat niet}}"
+          "en": "Task with [[filter]] !{{exists|does not exist}} in [[project]]",
+          "nl": "Taak with [[filter]] !{{bestaat|bestaat niet}} in [[project]]"
         },
         "hint": {
           "en": "Checks if any task with the filter exists. There might be multiple tasks that match.",
@@ -243,6 +243,19 @@
             "placeholder": {
               "en": "Do the laundry",
               "nl": "Doe de was"
+            }
+          },
+          {
+            "type": "autocomplete",
+            "name": "project",
+            "required": false,
+            "placeholder": {
+              "en": "Search for projects...",
+              "nl": "Zoek naar projecten..."
+            },
+            "title": {
+              "en": "Project",
+              "nl": "Project"
             }
           }
         ]
@@ -506,8 +519,8 @@
           "nl": "Voltooi taken met filter..."
         },
         "titleFormatted": {
-          "en": "Complete tasks with [[filter]]",
-          "nl": "Voltooi taken met [[filter]]"
+          "en": "Complete tasks with [[filter]] in [[project]]",
+          "nl": "Voltooi taken met [[filter]] in [[project]]"
         },
         "hint": {
           "en": "A filter that is not very specific has the potential the complete alot of tasks. Make sure you have a very specific filter.",
@@ -529,6 +542,19 @@
             "placeholder": {
               "en": "Do the laundry",
               "nl": "Was doen"
+            }
+          },
+          {
+            "type": "autocomplete",
+            "name": "project",
+            "required": false,
+            "placeholder": {
+              "en": "Search for projects...",
+              "nl": "Zoek naar projecten..."
+            },
+            "title": {
+              "en": "Project",
+              "nl": "Project"
             }
           }
         ]

--- a/drivers/user/driver.flow.compose.json
+++ b/drivers/user/driver.flow.compose.json
@@ -105,8 +105,8 @@
         "nl": "Taak met filter bestaat..."
       },
       "titleFormatted": {
-        "en": "Task with [[filter]] !{{exists|does not exist}} ",
-        "nl": "Taak with [[filter]] !{{bestaat|bestaat niet}}"
+        "en": "Task with [[filter]] !{{exists|does not exist}} in [[project]]",
+        "nl": "Taak with [[filter]] !{{bestaat|bestaat niet}} in [[project]]"
       },
       "hint": {
         "en": "Checks if any task with the filter exists. There might be multiple tasks that match.",
@@ -123,6 +123,19 @@
           "placeholder": {
             "en": "Do the laundry",
             "nl": "Doe de was"
+          }
+        },
+        {
+          "type": "autocomplete",
+          "name": "project",
+          "required": false,
+          "placeholder": {
+            "en": "Search for projects...",
+            "nl": "Zoek naar projecten..."
+          },
+          "title": {
+            "en": "Project",
+            "nl": "Project"
           }
         }
       ]
@@ -361,8 +374,8 @@
         "nl": "Voltooi taken met filter..."
       },
       "titleFormatted": {
-        "en": "Complete tasks with [[filter]]",
-        "nl": "Voltooi taken met [[filter]]"
+        "en": "Complete tasks with [[filter]] in [[project]]",
+        "nl": "Voltooi taken met [[filter]] in [[project]]"
       },
       "hint": {
         "en": "A filter that is not very specific has the potential the complete alot of tasks. Make sure you have a very specific filter.",
@@ -379,6 +392,19 @@
           "placeholder": {
             "en": "Do the laundry",
             "nl": "Was doen"
+          }
+        },
+        {
+          "type": "autocomplete",
+          "name": "project",
+          "required": false,
+          "placeholder": {
+            "en": "Search for projects...",
+            "nl": "Zoek naar projecten..."
+          },
+          "title": {
+            "en": "Project",
+            "nl": "Project"
           }
         }
       ]

--- a/drivers/user/driver.js
+++ b/drivers/user/driver.js
@@ -36,8 +36,14 @@ class UserDriver extends OAuth2Driver {
         throw new Error(this.homey.__('invalidFilter'));
       }
 
+      let filter = `search: ${args.filter}`;
+      if(args.project?.id) {
+        const project = await args.device.oAuth2Client.getProject({ project_id: args.project.id });
+        filter += ` & #${project.name}`;
+      }
+
       const tasks = await args.device.oAuth2Client.getTasks({
-        filter: `search: ${args.filter}`,
+        filter,
       });
 
       this.log(tasks);
@@ -46,6 +52,11 @@ class UserDriver extends OAuth2Driver {
         await args.device.oAuth2Client.closeTask(task.id);
       }));
     });
+
+    actionCompleteTasks.registerArgumentAutocompleteListener(
+      'project',
+      this.projectAutocompleteListener
+    );
   }
 
   /**
@@ -105,8 +116,14 @@ class UserDriver extends OAuth2Driver {
     const conditionTaskExists = this.homey.flow.getConditionCard('condition_task_exists');
 
     conditionTaskExists.registerRunListener(async (args, state) => {
+      let filter = `search: ${args.filter}`;
+      if(args.project?.id) {
+        const project = await args.device.oAuth2Client.getProject({ project_id: args.project.id });
+        filter += ` & #${project.name}`;
+      }
+
       const tasks = await args.device.oAuth2Client.getTasks({
-        filter: `search: ${args.filter}`,
+        filter
       });
 
       if (tasks.length > 0) {
@@ -115,6 +132,11 @@ class UserDriver extends OAuth2Driver {
 
       return false;
     });
+
+    conditionTaskExists.registerArgumentAutocompleteListener(
+      'project',
+      this.projectAutocompleteListener
+    );
   }
 
   registerProjectTaskAction() {


### PR DESCRIPTION
This PR will add an optional project field for searching or completing tasks, allowing for more convient scoped search within a project.

This change might be questionable, since you can already include `#[project-name]` in your filter. However, this change makes it a bit easier and ensures the filter continues to work if the project name changes, as it first retrieves the current project name using the project ID.