### PR TITLE
Replace the old legacy webhook with the new Key‑Path properties‑based implementation

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ class App extends OAuth2App {
     const secret = Homey.env.WEBHOOK_SECRET;
     const ids = [...this.ids];
 
-    const myWebhook = await this.homey.cloud.createWebhook(id, secret, { ids });
+    const myWebhook = await this.homey.cloud.createWebhook(id, secret, { $keys: ids });
 
     myWebhook.on('message', (args) => {
       const driver = this.homey.drivers.getDriver('user');


### PR DESCRIPTION
**Breaking change:** apps that do not upgrade will stop receiving webhook events.

This change is needed because the legacy webhook can no longer be created. This update is not strictly required for the app to continue functioning today, but it allows new developers to configure and test using a key-path-based webhook in place of the legacy one.

When this update is released, make sure to replace the existing legacy webhook with a key-path-based webhook (set to `body.user_id`), either after the release if that is allowed, or by setting up a new webhook and including it in this release. In either case, all apps must be updated, otherwise webhook events won't be properly delivered.