### PR TITLE
Upgrade to Todoist API v1

### DIFF
--- a/lib/TodoistClient.js
+++ b/lib/TodoistClient.js
@@ -37,7 +37,7 @@ class TodoistClient extends OAuth2Client {
     ...rest
   }) {
     return this.post({
-      path: '/rest/v2/tasks',
+      path: '/api/v1/tasks',
       json: {
         content: content,
         project_id: project_id,
@@ -52,51 +52,64 @@ class TodoistClient extends OAuth2Client {
   }
 
   async updateTask(task_id, body) {
-    return this.post({
-      path: `/rest/v2/tasks/${task_id}`,
+    const { results } = await this.post({
+      path: `/api/v1/tasks/${task_id}`,
       json: body,
     });
+
+    return results;
   }
 
   async closeTask(task_id) {
     return this.post({
-      path: `/rest/v2/tasks/${task_id}/close`,
+      path: `/api/v1/tasks/${task_id}/close`,
     });
   }
 
   async reopenTask(task_id) {
     return this.post({
-      path: `/rest/v2/tasks/${task_id}/reopen`,
+      path: `/api/v1/tasks/${task_id}/reopen`,
     });
   }
 
   async deleteTask(task_id) {
     return this.delete({
-      path: `/rest/v2/tasks/${task_id}`,
+      path: `/api/v1/tasks/${task_id}`,
     });
   }
 
-  async getTasks({ project_id, filter } = {}) {
-    // Query does not accept undefined. It will cause a bad request.
+  async getTasks({ project_id } = {}) {
+     // Query does not accept undefined. It will cause a bad request.
     const query = {};
 
     if (project_id != null) {
       query.project_id = project_id;
     }
 
-    if (filter != null) {
-      query.filter = filter;
-    }
-
-    return this.get({
-      path: '/rest/v2/tasks',
+    const { results } = await this.get({
+      path: '/api/v1/tasks',
       query: query,
     });
+
+    return results;
+  }
+
+  async getTasksByFilter({ filter }) {
+    const query = {
+      query: filter
+    };
+
+    const { results } = await this.get({
+      path: '/api/v1/tasks/filter',
+      query: query,
+    });
+
+    return results;
   }
 
   async getTask({ task_id }) {
     return this.get({
-      path: `/rest/v2/tasks/${task_id}`,
+      path: `/api/v1/tasks/${task_id}`,
     });
   }
 
@@ -105,9 +118,13 @@ class TodoistClient extends OAuth2Client {
       return await this._projects;
     }
 
-    this._projects = this.get({
-      path: '/rest/v2/projects ',
-    });
+    this._projects = (async () => {
+      const { results } = await this.get({
+        path: '/api/v1/projects ',
+      });
+
+      return results;
+    })();
 
     await this._projects;
 
@@ -122,13 +139,22 @@ class TodoistClient extends OAuth2Client {
 
   async getProject({ project_id }) {
     return this.get({
-      path: `/rest/v2/projects/${project_id}`,
+      path: `/api/v1/projects/${project_id}`,
     });
   }
 
   async getCollaborators({ project_id }) {
+    const { results } = await this.get({
+      path: `/api/v1/projects/${project_id}/collaborators`,
+    });
+
+    return results;
+  }
+
+  async getIdMappings({ object_name, ids }) {
+    this.log('getIdMappings using url', `/api/v1/id_mappings/${object_name}/${ids.join(',')}`);
     return this.get({
-      path: `/rest/v2/projects/${project_id}/collaborators`,
+      path: `/api/v1/id_mappings/${object_name}/${ids.join(',')}`,
     });
   }
 


### PR DESCRIPTION
This PR migrates the [old Todoist REST API](https://developer.todoist.com/rest/v2/#overview) to the new [API](https://developer.todoist.com/api/v1). _Despite the slightly confusing naming, as upgrading from v2 to v1 feels like going backwards._

This PR requires the webhook configuration to br updated in Todoist from the legacy version to v1. For now, the same events should be configured.

As part of the migration, I’ve added fallback/error handling for legacy IDs, since the new API uses different identifiers than the old REST API (see https://developer.todoist.com/api/v1/?shell#tag/Migrating-from-v9/General-changes/IDs). This fallback is intentionally limited to card actions only, as card configurations are likely to persist legacy IDs in user setups. The app APIs themselves are expected to be used in a more direct, programmatic way (e.g. fetching IDs and then immediately using them), so they should naturally operate on the new IDs. For that reason, no legacy ID fallback was added there.

This change also serves as pre-work for adding a widget that will be updated live via webhook messages. Since the V1 webhook events use the new IDs, they could not be matched to projects returned by the old REST API. Moving to the new API resolves this and enables proper webhook-based updates.

Over time, you could consider removing the .catch() blocks again that handles the deprecated identifiers.